### PR TITLE
FP-141

### DIFF
--- a/src/ckanext/nap_theme/fanstatic/custom.css
+++ b/src/ckanext/nap_theme/fanstatic/custom.css
@@ -80,7 +80,7 @@
 .nap-delete-confirm-collapser{
   max-height: 0px;
   overflow: hidden;
-
+  visibility: hidden;
   transition: max-height .25s ease-in-out;
 }
 

--- a/src/ckanext/nap_theme/fanstatic/delete-confirm.js
+++ b/src/ckanext/nap_theme/fanstatic/delete-confirm.js
@@ -1,11 +1,13 @@
 function openDeleteConfirm(target_id) {
     deleteConfirmContainer = document.getElementById(target_id);
     deleteConfirmContainer.style.maxHeight = deleteConfirmContainer.scrollHeight + "px";
+    deleteConfirmContainer.style.visibility = "visible";
 }
 
 function closeDeleteConfirm(target_id) {
     deleteConfirmContainer = document.getElementById(target_id);
     deleteConfirmContainer.style.maxHeight = null;
+    deleteConfirmContainer.style.visibility = "hidden";
 }
 
 window.addEventListener("DOMContentLoaded", function () {

--- a/src/ckanext/nap_theme/templates/user/snippets/package_item.html
+++ b/src/ckanext/nap_theme/templates/user/snippets/package_item.html
@@ -147,22 +147,19 @@ Example:
       <div class="nap-delete-confirm-container govuk-!-padding-5 govuk-!-margin-top-7 govuk-!-margin-bottom-5">
         <form id="confirm-dataset-delete-form" class="confirm-delete-form">
           <input type="hidden" id="deleteId{{package.id}}" name="id" value="{{package.id}}">
-
-          <fieldset class="govuk-fieldset">
-            <label class="govuk-label" for="delete-confirm">
-              <h4 class="govuk-heading-m">
-                {{_("Deleting this metadata entry is permanent and can't be undone.")}}
-              </h4>
-            </label>
-            <div class="govuk-button-group" id="delete-confirm">
-              <button class="govuk-button govuk-button--secondary govuk-!-margin-right-3" data-module="govuk-button" type="button" onclick='closeDeleteConfirm("delete-confirm-{{package.id}}")'>
-                {{_("Cancel")}}
-              </button>
-              <button class="govuk-button govuk-button--warning" type="submit" data-module="govuk-button" data-dataset="{{package.id}}">
-                {{_("Delete metadata entry")}}
-              </button>
-            </div>
-          </fieldset>
+          <label class="govuk-label" for="delete-confirm">
+            <h4 class="govuk-heading-m">
+              {{_("Deleting this metadata entry is permanent and can't be undone.")}}
+            </h4>
+          </label>
+          <div class="govuk-button-group" id="delete-confirm">
+            <button class="govuk-button govuk-button--secondary govuk-!-margin-right-3" data-module="govuk-button" type="button" onclick='closeDeleteConfirm("delete-confirm-{{package.id}}")'>
+              {{_("Cancel")}}
+            </button>
+            <button class="govuk-button govuk-button--warning" type="submit" data-module="govuk-button" data-dataset="{{package.id}}">
+              {{_("Delete metadata entry")}}
+            </button>
+          </div>
         </form>
       </div>
     </div>

--- a/src/ckanext/nap_theme/templates/user/snippets/package_item.html
+++ b/src/ckanext/nap_theme/templates/user/snippets/package_item.html
@@ -150,9 +150,9 @@ Example:
 
           <fieldset class="govuk-fieldset">
             <label class="govuk-label" for="delete-confirm">
-              <h3 class="govuk-heading-m">
+              <h4 class="govuk-heading-m">
                 {{_("Deleting this metadata entry is permanent and can't be undone.")}}
-              </h3>
+              </h4>
             </label>
             <div class="govuk-button-group" id="delete-confirm">
               <button class="govuk-button govuk-button--secondary govuk-!-margin-right-3" data-module="govuk-button" type="button" onclick='closeDeleteConfirm("delete-confirm-{{package.id}}")'>


### PR DESCRIPTION
Changes required to hide contents of collapable area from screen readers, and clean up for accessibility 
1. Removed unrequired fieldset 
2. Added hiden css property to delete confirmation
3. Changed the heading from H3 to H4
4. Updated js to show and hide the area. 